### PR TITLE
Add a link to a filebrowser instance for the device-backend's logs

### DIFF
--- a/web/app/package.json
+++ b/web/app/package.json
@@ -14,7 +14,7 @@
     "@rollup/plugin-replace": "^5.0.2",
     "@sargassum-world/styles": "^0.2.2",
     "bulma": "^0.9.4",
-    "eslint": "^8.47.0",
+    "eslint": "^8.48.0",
     "eslint-plugin-import": "^2.28.1",
     "prettier": "^3.0.2",
     "purify-css": "^1.2.5",

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -55,10 +55,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@^8.47.0":
-  version "8.47.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.47.0.tgz#5478fdf443ff8158f9de171c704ae45308696c7d"
-  integrity sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==
+"@eslint/js@8.48.0":
+  version "8.48.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.48.0.tgz#642633964e217905436033a2bd08bf322849b7fb"
+  integrity sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==
 
 "@fontsource/atkinson-hyperlegible@^5.0.9":
   version "5.0.9"
@@ -834,15 +834,15 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.47.0:
-  version "8.47.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.47.0.tgz#c95f9b935463fb4fad7005e626c7621052e90806"
-  integrity sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==
+eslint@^8.48.0:
+  version "8.48.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.48.0.tgz#bf9998ba520063907ba7bfe4c480dc8be03c2155"
+  integrity sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.6.1"
     "@eslint/eslintrc" "^2.1.2"
-    "@eslint/js" "^8.47.0"
+    "@eslint/js" "8.48.0"
     "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -44,6 +44,13 @@
             Provides a file browsing and management interface for the datasets collected by the PlanktoScope
           </li>
         </ul>
+        <p>System administration and troubleshooting:</p>
+        <ul>
+          <li>
+            <strong><a href="/admin/ps/device-backend-logs/browse/">Backend logs file manager</a></strong>:
+            Provides a file browsing and management interface for the PlanktoScope device backend's logs
+          </li>
+        </ul>
 
         <h2>Need help?</h2>
 


### PR DESCRIPTION
This PR adds a link to a new filebrowser instance which serves a GUI for browsing the log files produced by https://github.com/PlanktoScope/device-backend in the new logging location as a result of https://github.com/PlanktoScope/device-backend/pull/2