### PR TITLE
Make the landing page scrollable by arrow keys upon initial load

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,9 +12,9 @@ builds:
     - linux_amd64_v1
     - linux_arm64
     - linux_arm_7
-    - darwin_amd64_v1
-    - darwin_arm64
-    - windows_amd64_v1
+    # - darwin_amd64_v1
+    # - darwin_arm64
+    # - windows_amd64_v1
 
 archives:
   - id: device-portal

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -12,11 +12,11 @@
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-replace": "^5.0.2",
-    "@sargassum-world/styles": "^0.2.2",
+    "@sargassum-world/styles": "^0.3.0",
     "bulma": "^0.9.4",
     "eslint": "^8.48.0",
     "eslint-plugin-import": "^2.28.1",
-    "prettier": "^3.0.2",
+    "prettier": "^3.0.3",
     "purify-css": "^1.2.5",
     "rollup": "^3.28.1",
     "rollup-plugin-copy": "^3.4.0",
@@ -26,7 +26,7 @@
     "sass": "^1.66.1"
   },
   "dependencies": {
-    "@fontsource/atkinson-hyperlegible": "^5.0.9",
-    "@fontsource/oxygen-mono": "^5.0.9"
+    "@fontsource/atkinson-hyperlegible": "^5.0.11",
+    "@fontsource/oxygen-mono": "^5.0.11"
   }
 }

--- a/web/app/yarn.lock
+++ b/web/app/yarn.lock
@@ -60,15 +60,15 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.48.0.tgz#642633964e217905436033a2bd08bf322849b7fb"
   integrity sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==
 
-"@fontsource/atkinson-hyperlegible@^5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-5.0.9.tgz#688bf97cfd0f49a6b4932ca9ad7a1919bf0f590f"
-  integrity sha512-kFdxJvUEJC521EBvnL2Qhp1qQYnWiGhQAwzS1YvCF4FoyqCy1Rqx1Ok9d9n24VfAW1XZXE3AlXxUMHrYj6tmsA==
+"@fontsource/atkinson-hyperlegible@^5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@fontsource/atkinson-hyperlegible/-/atkinson-hyperlegible-5.0.11.tgz#603225ed9b21f0bcda34a8f0226b50109d48b95f"
+  integrity sha512-wHzGH0ykPXJa2fxliI6ZBplgQ09miYlHDml39g7ILy2h1+Dr/pMdmy4pimuWsRarCVk631atnrxZdJkxTyn20g==
 
-"@fontsource/oxygen-mono@^5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@fontsource/oxygen-mono/-/oxygen-mono-5.0.9.tgz#d01f98ecdf3b4bacef3c0b261e6b8d595f941614"
-  integrity sha512-3BIOEug9HzOCnlfZukG/WXhx4ZEs1df3EiAVkWXQA2AzGrBXCwsZDlnka2JTKvs5a5WnHYF3rt2nL1r14TvmGw==
+"@fontsource/oxygen-mono@^5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@fontsource/oxygen-mono/-/oxygen-mono-5.0.11.tgz#187cb146eef9b971e7137d15da94b7ae2a569b37"
+  integrity sha512-PWoVj2dpIu3S+vIYrQJU7VNTNQUMMcl5QCBUVbP0bwiVIcmSP6bSdpa2rE5YS3hUZQetGcIWdjklBB+U6ljkiw==
 
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
@@ -191,10 +191,10 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
-"@sargassum-world/styles@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@sargassum-world/styles/-/styles-0.2.2.tgz#3df48dff01ec1691f0c8f68326480a4e9471cede"
-  integrity sha512-Oxc3PrkVEB29LzqpbxfzyRKKkhnK8USHdC5VeQe2na9/6ImKBxOJT6Y0Zv34njnL3XUboDvyTjKZQ6sEdpZ2fA==
+"@sargassum-world/styles@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@sargassum-world/styles/-/styles-0.3.0.tgz#be152185fdde32b390d8f515d012666231b8fdf3"
+  integrity sha512-AKphUyCx7ViqebvukWP7n1Rf4Pf8M9nOYAfIJwGIHV3ba28TYZcmYoeCMi/nmjeLgfAn33/CdYbPH0FGbB4lkQ==
 
 "@types/estree@*":
   version "0.0.51"
@@ -1887,10 +1887,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.2.tgz#78fcecd6d870551aa5547437cdae39d4701dca5b"
-  integrity sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==
+prettier@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.3.tgz#432a51f7ba422d1469096c0fdc28e235db8f9643"
+  integrity sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==
 
 pseudomap@^1.0.2:
   version "1.0.2"

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -11,7 +11,7 @@
   {{$port := .Data.Port}}
   {{$machineName := .Data.MachineName}}
 
-  <main class="main-container">
+  <main>
     <section class="section content">
       <div class="container">
         <h1>PlanktoScope {{$machineName}}</h1>

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -17,15 +17,7 @@
         <h1>PlanktoScope {{$machineName}}</h1>
         <p>
           Welcome! This is the home page for your PlanktoScope with machine name
-          <code>{{$machineName}}</code>. If you're looking for a different PlanktoScope, you should
-          try to open it at its machine-specific URL.
-          {{if hasSuffix ".planktoscope" $hostname}}
-             For example, the machine-specific URL for this planktoscope is
-            <code>{{$machineName}}.planktoscope</code>.
-          {{else if and (hasPrefix "planktoscope" $hostname) (hasSuffix ".local" $hostname)}}
-             For example, the machine-specific URL for this planktoscope is
-            <code>planktoscope-{{$machineName}}.local</code>.
-          {{end}}
+          <code>{{$machineName}}</code>.
         </p>
         <p>
           Below you can find a list of links to browser applications provided by your PlanktoScope,
@@ -53,6 +45,29 @@
         </ul>
 
         <h2>Need help?</h2>
+
+        <h3 class="is-size-5">Wrong PlanktoScope?</h3>
+        <p>
+          If you're looking for a different PlanktoScope:
+        </p>
+        <ul>
+          <li>
+            You should navigate your web browser to that PlanktoScope's machine-specific URL
+            instead.
+            {{if hasSuffix ".planktoscope" $hostname}}
+              For example, the machine-specific URL for this PlanktoScope is
+              <code>{{$machineName}}.planktoscope</code>.
+            {{else if and (hasPrefix "planktoscope" $hostname) (hasSuffix ".local" $hostname)}}
+              For example, the machine-specific URL for this PlanktoScope is
+              <code>planktoscope-{{$machineName}}.local</code>.
+            {{end}}
+          </li>
+          <li>
+            If you're connecting locally to a PlanktoScope over Wi-Fi or Ethernet, you might need to
+            change your network configuration to connect to that PlanktoScope's Wi-Fi network or Ethernet
+            port, instead of <code>{{$machineName}}</code>'s Wi-Fi network or Ethernet port.
+          </li>
+        </ul>
 
         <h3 class="is-size-5">Documentation</h3>
         <p>Accessible offline:</p>

--- a/web/templates/shared/base.layout.tmpl
+++ b/web/templates/shared/base.layout.tmpl
@@ -35,8 +35,6 @@
 </head>
 
 <body>
-  <div class="main-window is-flex is-flex-direction-column-touch is-flex-direction-row-desktop">
-    {{block "content" .}}{{end}}
-  </div>
+  {{block "content" .}}{{end}}
 </body>
 </html>


### PR DESCRIPTION
Previously, due to the way https://github.com/sargassum-world/styles had set up the CSS with divs and flexboxes to enable a responsive navbar (at the top or at the side, depending on page width), the main content wasn't scrollable by arrow keys upon first load. However, the (current version of) device-portal doesn't need a navbar, so we can easily make the main content full-height and make the html body scrollable by default. This PR does that, and upgrades the `@sargassum-world/styles` npm package to v0.3.0 so that the body scrollbar is no longer deleted (this is necessary because it's impossible to simply override a `body::-webkit-scrollbar` selector's `display: none` attribute).

This PR also:
- Removes the goreleaser release builds for darwin and windows, since the device-portal is specifically meant to be deployed on Linux-based PlanktoScopes anyways. We can still restore those builds in the future, if necessary, and we still have (non-required) CI build checks for those platforms.
- Improves the instructions for finding other PlanktoScopes, and moves those instructions into the "Need Help?" section.