### PR TITLE
Update for shorter machine names and SSIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## 0.1.7 - 2023-09-06
+
+### Changed
+
+- Shortened machine names and updated information about machine-specific domain names and URLs to use the new `pkscope` abbreviation instead of `planktoscope` (see [PlanktoScope#214](https://github.com/PlanktoScope/PlanktoScope/pull/214)).
+
 ## 0.1.6 - 2023-08-10
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/PlanktoScope/machine-name v0.1.2
+	github.com/PlanktoScope/machine-name v0.1.3
 	github.com/benbjohnson/hashfs v0.2.1
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/labstack/echo/v4 v4.11.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7Y
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
-github.com/PlanktoScope/machine-name v0.1.2 h1:+xwlbwa2Hjf0WlUZPjRztD2AHsegwFjkqVB0tBw1cqA=
-github.com/PlanktoScope/machine-name v0.1.2/go.mod h1:lonYg8/9fOwpJZdV8w69nYw+VsOnEx14EXKw3VPvw54=
+github.com/PlanktoScope/machine-name v0.1.3 h1:vOorbZm5QcEJTrmruYpxX81eyWXJPQDNf2ZdydZdyy0=
+github.com/PlanktoScope/machine-name v0.1.3/go.mod h1:38x/CvfkMFPAr5xnnDyi0pfln7jo8e/oSVMQR4g+yoU=
 github.com/benbjohnson/hashfs v0.2.1 h1:pxfukDsRT7iwBcICHCNsqQoopYV+gUQw5yPDiYt8A6M=
 github.com/benbjohnson/hashfs v0.2.1/go.mod h1:7OMXaMVo1YkfiIPxKrl7OXkUTUgWjmsAKyR+E6xDIRM=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -55,31 +55,31 @@
           <li>
             You should use your web browser to open that PlanktoScope's machine-specific URL
             instead.
-            {{if hasSuffix ".planktoscope" $hostname}}
+            {{if hasSuffix ".pkscope" $hostname}}
               For example, the machine-specific URL for this PlanktoScope is
-              <a href="//{{$machineName}}.planktoscope">
+              <a href="//{{$machineName}}.pkscope">
                 {{- /* make template ignore the line break */ -}}
-                {{$machineName}}.planktoscope
+                {{$machineName}}.pkscope
                 {{- /* make template ignore the line break */ -}}
               </a>.
               Alternatively,
-              <a href="//planktoscope-{{$machineName}}.local">
+              <a href="//pkscope-{{$machineName}}.local">
                 {{- /* make template ignore the line break */ -}}
-                planktoscope-{{$machineName}}.local
+                pkscope-{{$machineName}}.local
                 {{- /* make template ignore the line break */ -}}
               </a>
               might also work if your web browser supports mDNS.
-            {{else if and (hasPrefix "planktoscope" $hostname) (hasSuffix ".local" $hostname)}}
+            {{else if and (hasPrefix "pkscope" $hostname) (hasSuffix ".local" $hostname)}}
               For example, the machine-specific URL for this PlanktoScope is
-              <a href="//planktoscope-{{$machineName}}.local">
+              <a href="//pkscope-{{$machineName}}.local">
                 {{- /* make template ignore the line break */ -}}
-                planktoscope-{{$machineName}}.local
+                pkscope-{{$machineName}}.local
                 {{- /* make template ignore the line break */ -}}
               </a>.
               Alternatively,
-              <a href="//{{$machineName}}.planktoscope">
+              <a href="//{{$machineName}}.pkscope">
                 {{- /* make template ignore the line break */ -}}
-                {{$machineName}}.planktoscope
+                {{$machineName}}.pkscope
                 {{- /* make template ignore the line break */ -}}
               </a>
               might also work if you're connecting directly to your PlanktoScope (i.e. to its
@@ -88,7 +88,7 @@
             {{end}}
           </li>
           <li>
-            {{if hasSuffix ".planktoscope" $hostname}}
+            {{if hasSuffix ".pkscope" $hostname}}
               You're probably trying to connect directly to your PlanktoScope (i.e. to its Ethernet
               port or to a Wi-Fi network created by that PlanktoScope). You
             {{else}}


### PR DESCRIPTION
This PR bumps the machine-name dependency and also updates the landing page information about machine-specific names and domain names in preparation for https://github.com/PlanktoScope/PlanktoScope/pull/214 . Specifically, it abbreviates "planktoscope" to "pkscope" in domain names.