### PR TITLE
Show deprecation note on landing page when `planktoscope.local` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Changed
+
+- All links now open in new tabs (see [PlanktoScope#231](https://github.com/PlanktoScope/PlanktoScope/pull/231)).
+- The landing page now shows a deprecation notice to the user if it is accessed using the `planktoscope.local` hostname.
+
 ## 0.1.7 - 2023-09-06
 
 ### Changed

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -24,6 +24,17 @@
           documentation for operating your PlanktoScope, and other information to help you use your PlanktoScope.
         </p>
 
+        {{if eq "planktoscope.local" $hostname}}
+          <article class="message is-warning">
+            <div class="message-body">
+              Note: the hostname <code>planktoscope.local</code> has been deprecated and should no
+              longer be used. Instead, you can use
+              <a href="//pkscope-{{$machineName}}.local">pkscope-{{$machineName}}.local</a>
+              or <a href="//pkscope.local">pkscope.local</a> to access this PlanktoScope.
+            </div>
+          </article>
+        {{end}}
+
         <h2>Browser applications</h2>
         <p>PlanktoScope operation:</p>
         <ul>


### PR DESCRIPTION
https://github.com/PlanktoScope/PlanktoScope/pull/214 deprecates `planktoscope.local` in favor of `pkscope.local`. This PR adds a deprecation message which is shown near the top of the landing page when it is accessed at hostname `planktoscope.local`.