### PR TITLE
Add link to Dozzle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- Added a link to the Dozzle log viewer.
+
 ## 0.1.12 - 2023-12-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## 0.1.13 - 2024-01-10
+
 ### Added
 
 - Added a link to the Dozzle log viewer.

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -211,6 +211,10 @@
             <strong><a href="/admin/portainer/" target="_blank">Portainer</a></strong>:
             Provides a Docker administration dashboard
           </li>
+          <li>
+            <strong><a href="/admin/dozzle/" target="_blank">Dozzle</a></strong>:
+            Provides a Docker container log viewer
+          </li>
         </ul>
         <p>Software development:</p>
         <ul>


### PR DESCRIPTION
This PR adds a landing page link to the Dozzle log viewer and bumps the version in the changelog for a release.