### PR TITLE
Add landing page entries for monitoring/metrics components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## 0.1.14 - 2024-01-11
+
 ### Added
 
 - Added a link to the Grafana dashboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- Added a link to the Grafana dashboard.
+- Added an API entry for the node-exporter host metrics.
+- Added an infrastructure entry for the Prometheus server.
+
 ## 0.1.13 - 2024-01-10
 
 ### Added

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -278,7 +278,7 @@
         <ul>
           <li>
             <strong>Host metrics</strong>:
-            Provides metrics about the Raspberry Pi at <code>{{$hostname}}:9100/metrics</code>
+            Provides Prometheus metrics about the Raspberry Pi at <code>{{$hostname}}:9100/metrics</code>
           </li>
         </ul>
 

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -53,6 +53,10 @@
             <strong><a href="/admin/ps/device-backend-logs/browse/" target="_blank">Backend logs file manager</a></strong>:
             Provides a file browsing and management interface for the PlanktoScope device backend's logs
           </li>
+          <li>
+            <strong><a href="/admin/grafana/" target="_blank">Grafana</a></strong>:
+            Provides a graphical dashboard for monitoring system and application metrics
+          </li>
         </ul>
 
         <h2>Need help?</h2>
@@ -208,12 +212,12 @@
             computer embedded in the PlanktoScope
           </li>
           <li>
-            <strong><a href="/admin/portainer/" target="_blank">Portainer</a></strong>:
-            Provides a Docker administration dashboard
-          </li>
-          <li>
             <strong><a href="/admin/dozzle/" target="_blank">Dozzle</a></strong>:
             Provides a Docker container log viewer
+          </li>
+          <li>
+            <strong><a href="/admin/portainer/" target="_blank">Portainer</a></strong>:
+            Provides a Docker administration dashboard
           </li>
         </ul>
         <p>Software development:</p>
@@ -270,6 +274,14 @@
           </li>
         </ul>
 
+        <p>System administration and troubleshooting:</p>
+        <ul>
+          <li>
+            <strong>Host metrics</strong>:
+            Provides metrics about the Raspberry Pi at <code>{{$hostname}}:9100/metrics</code>
+          </li>
+        </ul>
+
         <h3 class="is-size-5">System infrastructure</h3>
         <p>Networking:</p>
         <ul>
@@ -290,6 +302,14 @@
             <strong><a href="/" target="_blank">Device portal</a></strong>:
             Provides a landing page as a portal to the browser applications, network APIs, and system
             infrastructure on the PlanktoScope
+          </li>
+        </ul>
+
+        <p>System administration and troubleshooting:</p>
+        <ul>
+          <li>
+            <strong><a href="/admin/prometheus/" target="_blank">Prometheus server</a></strong>:
+            Records, aggregates, and monitors metrics
           </li>
         </ul>
       </div>

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -40,7 +40,7 @@
         <ul>
           <li>
             <strong><a href="/ps/node-red-v2/ui/" target="_blank">Node-RED dashboard</a></strong>:
-            Provides a Node-RED dashboard to operate the PlanktoScope
+            Provides the standard user interface to operate the PlanktoScope
           </li>
           <li>
             <strong><a href="/ps/data/browse/" target="_blank">Dataset file manager</a></strong>:
@@ -53,11 +53,6 @@
             <strong><a href="/admin/ps/device-backend-logs/browse/" target="_blank">Backend logs file manager</a></strong>:
             Provides a file browsing and management interface for the PlanktoScope device backend's logs
           </li>
-          <li>
-            <strong><a href="/admin/grafana/" target="_blank">Grafana</a></strong>:
-            Provides a graphical dashboard for monitoring system and application metrics
-          </li>
-        </ul>
 
         <h2>Need help?</h2>
 
@@ -219,6 +214,11 @@
             <strong><a href="/admin/portainer/" target="_blank">Portainer</a></strong>:
             Provides a Docker administration dashboard
           </li>
+          <li>
+            <strong><a href="/admin/grafana/" target="_blank">Grafana</a></strong>:
+            Provides a graphical dashboard for monitoring system and application metrics
+          </li>
+        </ul>
         </ul>
         <p>Software development:</p>
         <ul>


### PR DESCRIPTION
This PR adds links to the various parts of the Prometheus+Grafana monitoring system, as part of https://github.com/PlanktoScope/PlanktoScope/issues/252 .