### PR TITLE
Load machine-name directly, instead of generating it from a serial number

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters-settings:
   gocyclo:
     min-complexity: 15
   govet:
-    check-shadowing: true
+    shadow: true
   misspell:
     locale: US
   nolintlint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## 0.2.0 - 2024-04-22
+
+### Changed
+
+- (Breaking change) Instead of generating a machine name from a serial number which is either specified as the `MACHINENAME_SN` environment variable or loaded from a file specified by the `MACHINENAME_SNFILE` environment variable, now the device portal just tries to load the machine name from the `MACHINENAME_NAME` environment variable or else from a file specified by the `MACHINENAME_NAMEFILE` environment variable (which defaults to `/run/machine-name`), and it falls back to a name of "unknown" if no machine name is found.
+
 ## 0.1.15 - 2024-01-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ tar -xzf device-portal_{version number}_{os}_{cpu architecture}.tar.gz device-po
 
 Then you may need to move the device-portal binary into a directory in your system path, or you can just run the device-portal binary in your current directory (in which case you should replace `device-portal` with `./device-portal` in the commands listed below).
 
-Once you have device-portal, you should run it as follows on a Raspberry Pi:
+Once you have device-portal, you can run it as follows on a Raspberry Pi:
 ```
-device-portal
+./device-portal
 ```
 
-Then you can view the landing page at http://localhost:3000 . Note that if you are running it on a computer other than the Raspberry Pi with the standard PlanktoScope software distribution, then you will need to set some environment variables (see below) to non-default values.
+Then you can view the landing page at http://localhost:3000 . Note that if you are running it on a computer other than the Raspberry Pi with the standard PlanktoScope OS, then you will need to set some environment variables (see below) to non-default values.
 
 ### Development
 
@@ -39,14 +39,16 @@ To execute the full build pipeline, run `make`; to build the docker images, run 
 
 ### Environment Variables
 
-If you are running device-portal on a computer which is not a Raspberry Pi with the standard PlanktoScope software distribution, then you'll need to set some environment variables. Specifically, you'll need to set:
+If you are running device-portal on a computer which is not a Raspberry Pi with the standard PlanktoScope OS, then you'll need to set some environment variables. Specifically, you'll need to set:
 
-- Either `MACHINENAME_SN`, which should be a 32-bit hex number representing the computer's serial number (which is used for determining the computer's machine name to be displayed on the landing page), or `MACHINENAME_SNFILE`, which should be the path to a file containing a hex number, the least-significant 32 bits of which will be interpreted as a 32-bit serial number.
+- Either `MACHINENAME_NAME`, which should be a string representing the name of the machine to be displayed on the landing page, or `MACHINENAME_NAMEFILE`, which should be the path to a file containing the name of the machine to be displayed on the landing page.
 
-For example, you could run device-portal with the fake serial number `0xdeadc0de` using any of the following commands:
+For example, you could run device-portal with the machine name `metal-slope-23501` with one of the following commands:
 ```
-MACHINENAME_SN=deadc0de make run
-MACHINENAME_SN=0xdeadc0de make run
+# If you downloaded a device-portal binary:
+MACHINENAME_NAME=metal-slope-23501 ./device-portal
+# If you are developing the project:
+MACHINENAME_NAME=metal-slope-23501 make run
 ```
 
 ## Licensing

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3
-	github.com/PlanktoScope/machine-name v0.1.3
 	github.com/benbjohnson/hashfs v0.2.2
 	github.com/dgraph-io/ristretto v0.1.1
 	github.com/labstack/echo/v4 v4.11.4

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7Y
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
-github.com/PlanktoScope/machine-name v0.1.3 h1:vOorbZm5QcEJTrmruYpxX81eyWXJPQDNf2ZdydZdyy0=
-github.com/PlanktoScope/machine-name v0.1.3/go.mod h1:38x/CvfkMFPAr5xnnDyi0pfln7jo8e/oSVMQR4g+yoU=
 github.com/benbjohnson/hashfs v0.2.2 h1:vFZtksphM5LcnMRFctj49jCUkCc7wp3NP6INyfjkse4=
 github.com/benbjohnson/hashfs v0.2.2/go.mod h1:7OMXaMVo1YkfiIPxKrl7OXkUTUgWjmsAKyR+E6xDIRM=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=

--- a/internal/clients/machinename/conf.go
+++ b/internal/clients/machinename/conf.go
@@ -1,9 +1,6 @@
 package machinename
 
 import (
-	"fmt"
-
-	"github.com/PlanktoScope/machine-name/pkg/wordlists"
 	"github.com/pkg/errors"
 	"github.com/sargassum-world/godest/env"
 )
@@ -11,21 +8,15 @@ import (
 const envPrefix = "MACHINENAME_"
 
 type Config struct {
-	Lang   string
-	SNFile string
+	NameFile string
 
 	CacheCost float32
 }
 
 func GetConfig() (c Config, err error) {
-	c.Lang, err = getLangConfig()
-	if err != nil {
-		return Config{}, errors.Wrap(err, "couldn't make lang config")
-	}
-
-	// This is a file path specific to the Raspberry Pi
-	const defaultSNFilePath = "/sys/firmware/devicetree/base/serial-number"
-	c.SNFile = env.GetString(envPrefix+"SNFILE", defaultSNFilePath)
+	// This is a file path specific to the PlanktoScope OS
+	const defaultNameFilePath = "/run/machine-name"
+	c.NameFile = env.GetString(envPrefix+"NAMEFILE", defaultNameFilePath)
 
 	const defaultCacheCost = 1.0
 	c.CacheCost, err = env.GetFloat32(envPrefix+"CACHE_COST", defaultCacheCost)
@@ -33,20 +24,4 @@ func GetConfig() (c Config, err error) {
 		return Config{}, errors.Wrap(err, "couldn't make cache cost config")
 	}
 	return c, nil
-}
-
-func getLangConfig() (lang string, err error) {
-	const defaultLang = "en_US.UTF-8"
-	lang = env.GetString("LANG", defaultLang)
-
-	allowed, err := wordlists.ListLanguages(wordlists.FS)
-	if err != nil {
-		return "", errors.Wrap(err, "couldn't determine the list of supported languages")
-	}
-	if _, ok := allowed[lang]; !ok {
-		// FIXME: log this warning properly
-		fmt.Printf("Warning: language '%s' is not supported, reverting to '%s'\n", lang, defaultLang)
-		lang = defaultLang
-	}
-	return lang, nil
 }


### PR DESCRIPTION
This PR accompanies changes made in https://github.com/PlanktoScope/device-pkgs/pull/9 (which saves the machine name to `/run/machine-name`), by just loading the machine name from there instead of trying to load a Raspberry Pi-specific serial number.

This PR removes device-portal's direct use of https://github.com/PlanktoScope/machine-name and allows manual overrides of the machine name (by replacing the PlanktoScope OS's default service for generating `/run/machine-name` with a custom service to generate it some other way) to be used for the device-portal.

This PR will also hopefully help to simplify testing of the PlanktoScope setup scripts in Debian VMs, by allowing pallet-standard to be applied successfully by the setup script before reboot instead of having it fail because the Raspberry Pi-specific path of its serial number (previously required by device-portal) doesn't exist in Debian.