### PR TITLE
Update landing page links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Fixed
+
+- The links to the offline copies of the operation protocols are no longer broken.
+
 ## 0.2.1 - 2024-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Removed
+
+- The links to Portainer have been removed, as part of the deprecation of Portainer in the default configuration of v2024.0.0 of the PlanktoScope OS.
+
 ### Fixed
 
 - The links to the offline copies of the operation protocols are no longer broken.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+## 0.2.2 - 2024-05-25
+
 ### Removed
 
 - The links to Portainer have been removed, as part of the deprecation of Portainer in the default configuration of v2024.0.0 of the PlanktoScope OS.

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -212,10 +212,6 @@
             Provides a Docker container log viewer
           </li>
           <li>
-            <strong><a href="/admin/portainer/" target="_blank">Portainer</a></strong>:
-            Provides a Docker administration dashboard
-          </li>
-          <li>
             <strong><a href="/admin/grafana/" target="_blank">Grafana</a></strong>:
             Provides a graphical dashboard for monitoring system and application metrics
           </li>
@@ -235,11 +231,6 @@
               {{- /* make template ignore the line break */ -}}
             </a></strong>:
             Provides fallback access to the Cockpit application, accessible even if the system's
-            service proxy stops working
-          </li>
-          <li>
-            <strong><a href="//{{$hostname}}:9000" target="_blank">Portainer (direct-access fallback)</a></strong>:
-            Provides fallback access to the Portainer application, accessible even if the system's
             service proxy stops working
           </li>
         </ul>

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -121,7 +121,7 @@
             Provides an offline copy of the official PlanktoScope project documentation
           </li>
           <li>
-            <strong><a href="/ps/docs/usage/protocol-v2.pdf" target="_blank">
+            <strong><a href="/ps/docs/operation/protocol-v2.pdf" target="_blank">
               Protocol for plankton imaging, v2
               {{- /* make template ignore the line break */ -}}
             </a></strong>:
@@ -130,7 +130,7 @@
             PlanktoScope software
           </li>
           <li>
-            <strong><a href="/ps/docs/usage/protocol-v1.pdf" target="_blank">
+            <strong><a href="/ps/docs/operation/protocol-v1.pdf" target="_blank">
               Protocol for plankton imaging, v1
               {{- /* make template ignore the line break */ -}}
             </a></strong>:


### PR DESCRIPTION
This PR fixes broken links to the offline docs site's PDF copies of the PlanktoScope operation protocols. This PR also removes links to Portainer, since v2024.0.0 of PlanktoScope OS [deprecates](https://github.com/PlanktoScope/PlanktoScope/pull/399) the inclusion of Portainer in the default SD card images of PlanktoScope OS.