### PR TITLE
Add warning message about hostnames on external networks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 
 ## Unreleased
 
+### Added
+
+- A warning has been added when the user access the landing page using any hostname other than `pkscope-{machine-name}.local`, that such a hostname will not work for accessing the PlanktoScope via a Wi-Fi router or Ethernet router, and instead `pkscope-{machine-name}.local` must be used in such situations.
+
+## 0.2.3 - 2024-06-21
+
 ### Removed
 
 - The deprecation warning for the `planktoscope.local` hostname has been removed, as that hostname is being undeprecated for v2024.0.0 (starting with v2024.0.0-beta.1).

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -24,6 +24,21 @@
           documentation for operating your PlanktoScope, and other information to help you use your PlanktoScope.
         </p>
 
+        {{if not (and (hasPrefix "pkscope-" $hostname) (hasSuffix ".local" $hostname))}}
+          <article class="message is-warning">
+            <div class="message-body">
+              Note: you are using the hostname <code>{{$hostname}}</code>, which only works when you
+              are connecting directly to the PlanktoScope through its Wi-Fi hotspot or through an
+              Ethernet cable. If/when you want to connect to the PlanktoScope through a Wi-Fi router
+              or Ethernet router (for example because you have connected your PlanktoScope to the
+              internet through an external Wi-Fi network, which disables the PlanktoScope's Wi-Fi
+              hotspot), you will instead need to use
+              <a href="//pkscope-{{$machineName}}.local">pkscope-{{$machineName}}.local</a>
+              to access this PlanktoScope.
+            </div>
+          </article>
+        {{end}}
+
         <h2>Browser applications</h2>
         <p>PlanktoScope operation:</p>
         <ul>

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -69,7 +69,7 @@
                 {{- /* make template ignore the line break */ -}}
               </a>
               might also work if your web browser supports mDNS.
-            {{else if and (hasPrefix "pkscope" $hostname) (hasSuffix ".local" $hostname)}}
+            {{else if hasSuffix ".local" $hostname}}
               For example, the machine-specific URL for this PlanktoScope is
               <a href="//pkscope-{{$machineName}}.local">
                 {{- /* make template ignore the line break */ -}}


### PR DESCRIPTION
This PR adds a warning shown near the top of the landing page, when the user access the PlanktoScope via IP address or `planktoscope.local` or `pkscope.local` or `*.pkscope`, that those names only work via the PlanktoScope's Wi-Fi hotspot or a direct Ethernet connection; and that only `pkscope-{machine-name}.local` can be used for accessing the PlanktoScope via a Wi-Fi/Ethernet router.

This implements a suggestion discussed with @fabienlombard [on the PlanktoScope Slack](https://planktoscope.slack.com/archives/C01V5ENKG0M/p1730826559536019?thread_ts=1730269272.159869&cid=C01V5ENKG0M).