### PR TITLE
Add links for v3 of Fabien's PlanktoScope operation protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 All dates in this file are given in the [UTC time zone](https://en.wikipedia.org/wiki/Coordinated_Universal_Time).
 
-## Unreleased
+## 0.2.4 - 2024-11-28
 
 ### Added
 
-- A warning has been added when the user access the landing page using any hostname other than `pkscope-{machine-name}.local`, that such a hostname will not work for accessing the PlanktoScope via a Wi-Fi router or Ethernet router, and instead `pkscope-{machine-name}.local` must be used in such situations.
+- A warning has been added when the user accesses the landing page using any hostname other than `pkscope-{machine-name}.local`, that such a hostname will not work for accessing the PlanktoScope via a Wi-Fi router or Ethernet router, and instead `pkscope-{machine-name}.local` must be used in such situations.
 - A link has been added to a (new) offline/PDF copy of [version 3 of Fabien's PlanktoScope operation protocol](https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v3).
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All dates in this file are given in the [UTC time zone](https://en.wikipedia.org
 ### Added
 
 - A warning has been added when the user access the landing page using any hostname other than `pkscope-{machine-name}.local`, that such a hostname will not work for accessing the PlanktoScope via a Wi-Fi router or Ethernet router, and instead `pkscope-{machine-name}.local` must be used in such situations.
+- A link has been added to a (new) offline/PDF copy of [version 3 of Fabien's PlanktoScope operation protocol](https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v3).
+
+### Removed
+
+- The link to the offline/PDF copy of [version 1 of Fabien's PlanktoScope operation protocol](https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v1) has been removed. The link to the online version remains.
 
 ## 0.2.3 - 2024-06-21
 

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -142,15 +142,6 @@
             using version 2.5 of the official PlanktoScope hardware and version 2.3 of the official
             PlanktoScope software
           </li>
-          <li>
-            <strong><a href="/ps/docs/operation/protocol-v1.pdf" target="_blank">
-              Protocol for plankton imaging, v1
-              {{- /* make template ignore the line break */ -}}
-            </a></strong>:
-            Provides an offline copy of version 1 of the protocol for quantifying plankton diversity
-            using versions 2.1-2.3 of the official PlanktoScope hardware and version 2.3 of the
-            official PlanktoScope software
-          </li>
         </ul>
         <p>On the internet:</p>
         <ul>

--- a/web/templates/home/home.page.tmpl
+++ b/web/templates/home/home.page.tmpl
@@ -125,6 +125,15 @@
             Provides an offline copy of the official PlanktoScope project documentation
           </li>
           <li>
+            <strong><a href="/ps/docs/operation/protocol-v3.pdf" target="_blank">
+              Protocol for plankton imaging, v3
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            Provides an offline copy of version e of the protocol for quantifying plankton diversity
+            using version 2.5 of the official PlanktoScope hardware and version 2.3 of the official
+            PlanktoScope software
+          </li>
+          <li>
             <strong><a href="/ps/docs/operation/protocol-v2.pdf" target="_blank">
               Protocol for plankton imaging, v2
               {{- /* make template ignore the line break */ -}}
@@ -148,6 +157,14 @@
           <li>
             <strong><a href="https://docs.planktoscope.community" target="_blank">PlanktoScope project documentation</a></strong>:
             Provides the latest version of the PlanktoScope project documentation
+          </li>
+          <li>
+            <strong><a href="https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v3?version_warning=no" target="_blank">
+              Protocol for plankton imaging, v3
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            Provides version 3 of the protocol for quantifying plankton diversity using version 2.5
+            of the official PlanktoScope hardware and version 2.3 of the official PlanktoScope software
           </li>
           <li>
             <strong><a href="https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v2?version_warning=no" target="_blank">


### PR DESCRIPTION
This PR links to https://www.protocols.io/view/planktoscope-protocol-for-plankton-imaging-bp2l6bq3zgqe/v3 (including an offline/PDF copy added by https://github.com/PlanktoScope/PlanktoScope/pull/495) and removes the link to the PDF of the v1 protocol (as that PDF is removed by https://github.com/PlanktoScope/PlanktoScope/pull/495), as part of a request made by @fabienlombard [on the PlanktoScope Slack](https://planktoscope.slack.com/archives/C01V5ENKG0M/p1730903239869889?thread_ts=1730269272.159869&cid=C01V5ENKG0M) for the device-portal landing page.